### PR TITLE
Fixes typo in German language

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -9,7 +9,7 @@
   "SMLTME.Resting_Opacity": "Transparenz bei Inaktivität",
   "SMLTME.Resting_Opacity_Hint": "Transparenz des SmallTime-Fensters, wenn nicht damit interagiert wird.",
   "SMLTME.Darkness_Default": "Dunkelheit Standardmäßig beeinflussen",
-  "SMLTME.Darkness_Default_Hint": "Standardeinstellung für SmalTime Dunkelheitseinfluss in der Szenenkonfiguration",
+  "SMLTME.Darkness_Default_Hint": "Standardeinstellung für SmallTime Dunkelheitseinfluss in der Szenenkonfiguration",
   "SMLTME.Darkness_Control": "SmallTime Dunkelheitseinfluss",
   "SMLTME.Darkness_Control_Hint": "Koppelt die Dunkelheitseinstellung dieser Szene an die aktuelle Zeit in SmallTime.",
   "SMLTME.AboutTime": "Mit About Time synchronisieren",


### PR DESCRIPTION
SmalTime to SmallTime in this lables:
* SMLTME.Darkness_Default_Hint
* SMLTME.Darkness_Default