### PR TITLE
Prevent "escape" keypress from closing SmallTime

### DIFF
--- a/scripts/smalltime.js
+++ b/scripts/smalltime.js
@@ -440,6 +440,33 @@ class SmallTimeApp extends FormApplication {
     this.currentTime = game.settings.get('smalltime', 'current-time');
   }
 
+  // Override original #close method inherited from parent class (FormApplication)
+  async close(options={}) { // Same signature as original method
+
+    // If called by SmallTime (line 1008), use original method to handle app closure
+    if (options.smallTime) return super.close();
+
+    // Otherwise, this method was probably called by Case 2 of KeyboardManager#_onEscape (which is called when an "Escape" keypress is registered)
+    // Handle the "Escape" keypress behaviour manually; Based on KeyboardManager#_onEscape (line 2907 in foundry.js)
+    
+    // Case 1 - Close OTHER open UI windows
+    if (Object.keys(ui.windows).length > 1) { // If there is ANOTHER app open
+      Object.values(ui.windows).forEach(app => { // Loop through each app
+        if (app.title === "SmallTime") return; // If the current app is SmallTime, skip it
+        app.close(); // Close the current app
+      });
+    }
+
+    // Case 2 (GM) - Release controlled objects
+    else if (canvas?.ready && game.user.isGM && Object.keys(canvas.activeLayer._controlled).length) {
+      event.preventDefault();
+      canvas.activeLayer.releaseAll();
+    }
+
+    // Case 3 - Toggle the main menu
+    else ui.menu.toggle();
+  }
+
   static get defaultOptions() {
     const pinned = game.settings.get('smalltime', 'pinned');
 
@@ -978,7 +1005,7 @@ class SmallTimeApp extends FormApplication {
         $('#smalltime-app').stop();
         $('#smalltime-app').css({ animation: 'close 0.2s', opacity: '0' });
         setTimeout(function () {
-          game.modules.get('smalltime').myApp.close();
+          game.modules.get('smalltime').myApp.close({smallTime: true}); // Pass an object into the #close call to distinguish that it came from SmallTime and not an "Escape" keypress
         }, 200);
         game.settings.set('smalltime', 'visible', false);
       } else {


### PR DESCRIPTION
Override `SmallTimeApp.close` (inherited from FormApplication) to determine if the method was called by `SmallTimeApp` or by an "escape" keypress.
If called by `SmallTimeApp`, proceed as normal, using inherited method.
If not, handle "escape" keypress behavior manually, based on KeyboardManager._onEscape of foundry.js (called on "escape" keypress).

Feel free to remove the comments and lemme know if you see any issues!

`enso#0361`