### PR TITLE
fix: transition darkness when daylight uses non-zero darkness level

### DIFF
--- a/scripts/smalltime.js
+++ b/scripts/smalltime.js
@@ -1445,16 +1445,15 @@ class SmallTimeApp extends FormApplication {
 
       if (minDarkness > maxDarkness) {
         if (timeNow >= sunriseStart && timeNow <= sunriseEnd) {
-          darknessValue = ((timeNow - sunriseStart) / (sunriseEnd - sunriseStart)) * multiplier;
+          darknessValue = maxDarkness + ((timeNow - sunriseStart) / (sunriseEnd - sunriseStart)) * multiplier;
         } else if (timeNow >= sunsetStart && timeNow <= sunsetEnd) {
-          darknessValue = (1 - (timeNow - sunsetStart) / (sunsetEnd - sunsetStart)) * multiplier;
+          darknessValue = maxDarkness + (1 - (timeNow - sunsetStart) / (sunsetEnd - sunsetStart)) * multiplier;
         }
       } else {
         if (timeNow >= sunriseStart && timeNow <= sunriseEnd) {
-          darknessValue = (1 - ((timeNow - sunriseStart) / (sunriseEnd - sunriseStart))) * multiplier;
+          darknessValue = minDarkness + (1 - ((timeNow - sunriseStart) / (sunriseEnd - sunriseStart))) * multiplier;
         } else if (timeNow >= sunsetStart && timeNow <= sunsetEnd) {
-          darknessValue =
-            (1 - (1 - (timeNow - sunsetStart) / (sunsetEnd - sunsetStart))) * multiplier;
+          darknessValue = minDarkness + ((timeNow - sunsetStart) / (sunsetEnd - sunsetStart)) * multiplier;
         }
       }
       // Truncate long decimals.


### PR DESCRIPTION
Another small fix when the lower of darkness settings is not 0.
i.e.:
const sunriseStart = 100;
const sunriseEnd = 200;
const timeNow = 101;
const minDarkness = 0.2;
const maxDarkness = 0.8;

before darknessValue would be 0.6
now darknessValue is 0.8