### PR TITLE
Separating scene settings into multiple form groups

### DIFF
--- a/scripts/smalltime.js
+++ b/scripts/smalltime.js
@@ -534,12 +534,16 @@ Hooks.on('renderSceneConfig', async (obj) => {
           <option value="0" ${vis0}>${vis0text}</option>
         </select>
         <p class="notes">${visibilityHint}</p>
+      </div>
+      <div class="form-group">
         <label>${controlLabel}</label>
         <input
           type="checkbox"
           name="flags.smalltime.darkness-link"
           ${darknessCheckStatus}>
         <p class="notes">${controlHint}</p>
+      </div>
+      <div class="form-group">
         <label>${moonlightLabel}</label>
         <input
           type="checkbox"


### PR DESCRIPTION
Provides better compatability with [Mass Edit](https://github.com/Aedif/multi-token-edit) module while having minial impact on the look of the settings. https://github.com/unsoluble/smalltime/issues/142


Before:

![smallTimeBefore](https://user-images.githubusercontent.com/7693704/187491370-bc70fa3a-7866-49f4-bc37-92efc3398b9e.png)

After:

![smallTimeAfter](https://user-images.githubusercontent.com/7693704/187491385-ab61eba4-35ad-4f5e-a0bb-c8e75acc3fe3.png)
