### PR TITLE
Multiple moons brightness calculations

### DIFF
--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -712,30 +712,35 @@ export class Helpers {
 
   // Overriding the Vision Limitation Threshold value for the scene if requested.
   // Values span from 0.0 to 1.0 to mimic brightness levels of the various phases.
-  static async adjustMoonlight(phase) {
+  static async adjustMoonlight(phases) {
     // Only perform this adjustment if the setting is enabled.
-    if (!game.scenes.viewed.getFlag('smalltime', 'moonlight')) return;
-    let newThreshold;
-    switch (phase) {
-      case 0: // new
-        newThreshold = 0;
-        break;
-      case 1: // waxing crescent
-      case 7: // waning crescent
-        newThreshold = 0.25;
-        break;
-      case 2: // first quarter
-      case 6: // last quarter
-        newThreshold = 0.5;
-        break;
-      case 3: // waxing gibbous
-      case 5: // waning gibbous
-        newThreshold = 0.75;
-        break;
-      case 4: // full
-        newThreshold = 1;
-        break;
-    }
+    if (!game.scenes.viewed.getFlag('smalltime', 'moonlight') || !phases.length) return;
+    let newThreshold = 0;
+    phases.forEach(phase => {
+      switch (phase) {
+        case 0: // new
+          newThreshold += 0;
+          break;
+        case 1: // waxing crescent
+        case 7: // waning crescent
+          newThreshold += 0.25;
+          break;
+        case 2: // first quarter
+        case 6: // last quarter
+          newThreshold += 0.5;
+          break;
+        case 3: // waxing gibbous
+        case 5: // waning gibbous
+          newThreshold += 0.75;
+          break;
+        case 4: // full
+          newThreshold += 1;
+          break;
+      }
+    });
+
+    newThreshold = Math.round(newThreshold / phases.length * 100) / 100;
+    
     if (newThreshold === game.scenes.viewed.data.globalLightThreshold) {
       return true;
     }

--- a/scripts/smalltime-app.mjs
+++ b/scripts/smalltime-app.mjs
@@ -525,7 +525,6 @@ Hooks.on('renderSceneConfig', async (obj) => {
       .parent()
       .after(injection);
   }
-
   // Re-auto-size the app window.
   obj.setPosition();
 
@@ -960,7 +959,7 @@ class SmallTimeApp extends FormApplication {
         // Set and broadcast the change.
         if (game.user.isGM) {
           await game.settings.set('smalltime', 'moon-phase', newPhase);
-          Helpers.adjustMoonlight(newPhase);
+          Helpers.adjustMoonlight([newPhase]);
         } else {
           SmallTimeApp.emitSocket('changeSetting', {
             scope: 'smalltime',
@@ -1105,12 +1104,17 @@ class SmallTimeApp extends FormApplication {
         if (typeof data.moons[0] === 'undefined') {
           return;
         }
-        const newPhase = ST_Config.MoonPhases.findIndex(function (phase) {
-          return phase === data.moons[0].currentPhase.icon;
-        });
-        await game.settings.set('smalltime', 'moon-phase', newPhase);
+        const newPhases = [];
+        data.moons.forEach(m => {
+          const newPhase = ST_Config.MoonPhases.findIndex(function (phase) {
+            return phase === m.currentPhase.icon;
+          });
+          newPhases.push(newPhase);
+        })
+        
+        await game.settings.set('smalltime', 'moon-phase', newPhases[0]);
         SmallTimeApp.timeTransition(Helpers.getWorldTimeAsDayTime());
-        Helpers.adjustMoonlight(newPhase);
+        Helpers.adjustMoonlight(newPhases);
       });
     }
   }
@@ -1284,7 +1288,6 @@ class SmallTimeApp extends FormApplication {
     const app = game.modules.get('smalltime').myApp;
     if (app && app.element.hasClass('pinned')) {
       const element = app.element;
-
       $('body').append(element);
       element.removeClass('pinned');
 


### PR DESCRIPTION
This changes allows multiple moons to be taken into account from SimpleCalendar when calculating the brightness threshold. It partially solves https://github.com/unsoluble/smalltime/issues/159

The display still only shows the phase of the first moon but I think that's fine 